### PR TITLE
Fix block comment

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "groovy"
 name = "Groovy"
-version = "1.3.0"
+version = "1.3.1"
 schema_version = 1
 authors = ["Valentine Briese <valentinegb@icloud.com>"]
 description = "Groovy (build.gradle) support."

--- a/languages/groovy/config.toml
+++ b/languages/groovy/config.toml
@@ -16,5 +16,5 @@ brackets = [
 autoclose_before = ",]}>"
 collapsed_placeholder = " /* ... */ "
 line_comments = ["// "]
-block_comment = { start = "/*", end = "*/", prefix = "", tab_size = 0 }
+block_comment = ["/*", "*/"]
 documentation_comment = { start = "/**", end = "*/", prefix = "* ", tab_size = 1 }


### PR DESCRIPTION
Updated fix for #3 

It appears that the PR for Zed extensions is failing, https://github.com/zed-industries/extensions/pull/3129

I hope it is ok that I included the version bump as well. I tested the extension locally and the version bumped to v1.3.1 and the extension loaded.